### PR TITLE
 modified README page to be sure heroku deploys app

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 An application for planning meals and generating a calorie count depending on the food type chosen.
 
 ## Links
-[Deploy from Heroku](https://carolhgray.github.io/food-tracker/
-https://afternoon-depths-27329-136310a7316d.herokuapp.com/)
+[Deploy from Heroku](https://afternoon-depths-27329-136310a7316d.herokuapp.com/)
 
 ## Usage
 Created to receive user log-in information and food type chosen, and then output a calorie count into a display with details. All of the user inputs will save until user is replaced.  Sign-up page lets new users create account.


### PR DESCRIPTION
The README page should deploy the app using Heroku.  A small change in syntax for the deploy command was made.  The URL address should only have the heroku address.